### PR TITLE
DOC: Add codecov status badge to NumPy README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Travis](https://img.shields.io/travis/numpy/numpy/master.svg?label=Travis%20CI)](https://travis-ci.org/numpy/numpy)
 [![AppVeyor](https://img.shields.io/appveyor/ci/charris/numpy/master.svg?label=AppVeyor)](https://ci.appveyor.com/project/charris/numpy)
+[![codecov](https://codecov.io/gh/numpy/numpy/branch/master/graph/badge.svg)](https://codecov.io/gh/numpy/numpy)
 
 NumPy is the fundamental package needed for scientific computing with Python.
 


### PR DESCRIPTION
It was copy / pasted from the SciPy version, and then adjusted for markdown instead of rst format.